### PR TITLE
prod-sync: /api/logout robuste (GET/POST/OPTIONS+CORS), routage Traef…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ backend/db.sqlite3
 frontend/.env.development.local
 # backups
 backups/
+.env.prod.local

--- a/backend/api/views_logout.py
+++ b/backend/api/views_logout.py
@@ -1,0 +1,30 @@
+import os
+from django.http import HttpResponse
+from django.contrib.auth import logout as django_logout
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+FRONT_ORIGIN = os.getenv("FRONT_ORIGIN", "https://mdp.mon-site.ca")
+
+def _add_cors(resp, origin=FRONT_ORIGIN):
+    # Pour cookies, il faut une origine explicite (pas "*")
+    resp["Access-Control-Allow-Origin"] = origin
+    resp["Vary"] = "Origin"
+    resp["Access-Control-Allow-Credentials"] = "true"
+    resp["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+    resp["Access-Control-Allow-Headers"] = "Content-Type, X-CSRFToken, X-Requested-With"
+    return resp
+
+def _wipe_cookies(resp):
+    for name in ("sessionid", "csrftoken"):
+        resp.delete_cookie(name, path="/")
+
+@csrf_exempt
+@require_http_methods(["GET", "POST", "OPTIONS"])
+def api_logout(request):
+    if request.method == "OPTIONS":
+        return _add_cors(HttpResponse(status=204))
+    django_logout(request)
+    resp = HttpResponse(status=204)
+    _wipe_cookies(resp)
+    return _add_cors(resp)

--- a/backend/gestionnaire_mdp/urls.py
+++ b/backend/gestionnaire_mdp/urls.py
@@ -1,13 +1,16 @@
 from django.contrib import admin
 from django.urls import path, include
-from django.http import JsonResponse
-from django.middleware.csrf import get_token
+from django.http import HttpResponse
+from django.views.decorators.csrf import ensure_csrf_cookie
+from api.views_logout import api_logout
 
+@ensure_csrf_cookie
 def csrf_view(request):
-    return JsonResponse({"csrfToken": get_token(request)})
+    return HttpResponse(status=204)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('api.urls')),   # ← toute l'API sous /api/
-    path('api/csrf/', csrf_view),        # ← endpoint pour déposer le cookie CSRF
+    path('api/logout/', api_logout, name='api-logout'),
+    path('api/csrf/', csrf_view, name='api-csrf'),
+    path('api/', include('api.urls')),
 ]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: postgres:16-alpine
@@ -9,9 +7,9 @@ services:
       - .env.prod
       - .env.prod.local
     environment:
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      POSTGRES_DB: "${POSTGRES_DB}"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
     volumes:
       - mdp_prod_pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -35,22 +33,56 @@ services:
       - .env.prod
       - .env.prod.local
     environment:
-      - DB_HOST=db
-      - DB_PORT=5432
-      - DB_NAME=${POSTGRES_DB}
-      - DB_USER=${POSTGRES_USER}
-      - DB_PASSWORD=${POSTGRES_PASSWORD}
-      - DJANGO_DEBUG=0
-      - ALLOWED_HOSTS=mdp-api.mon-site.ca
-      - CSRF_TRUSTED_ORIGINS=http://mdp-api.mon-site.ca,http://mdp.mon-site.ca,https://mdp-api.mon-site.ca,https://mdp.mon-site.ca
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: "${POSTGRES_DB}"
+      DB_USER: "${POSTGRES_USER}"
+      DB_PASSWORD: "${POSTGRES_PASSWORD}"
+      DJANGO_DEBUG: "0"
+      ALLOWED_HOSTS: "mdp-api.mon-site.ca,mdp.mon-site.ca"
+      CSRF_TRUSTED_ORIGINS: "http://mdp-api.mon-site.ca,http://mdp.mon-site.ca,https://mdp-api.mon-site.ca,https://mdp.mon-site.ca"
     expose:
       - "8000"
     labels:
       traefik.enable: "true"
       traefik.docker.network: "edge"
+
+      # Middleware redirection HTTP -> HTTPS
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: "https"
+
+      # ===== Domaine API direct (mdp-api.mon-site.ca) =====
+      # HTTP -> redirige
+      traefik.http.routers.mdp_api_http.rule: "Host(`mdp-api.mon-site.ca`)"
+      traefik.http.routers.mdp_api_http.entrypoints: "web"
+      traefik.http.routers.mdp_api_http.middlewares: "redirect-to-https"
+      traefik.http.routers.mdp_api_http.service: "mdp_api"
+
+      # HTTPS -> sert l'API/Admin
       traefik.http.routers.mdp_api.rule: "Host(`mdp-api.mon-site.ca`)"
-      traefik.http.routers.mdp_api.entrypoints: "web"
+      traefik.http.routers.mdp_api.entrypoints: "websecure"
+      traefik.http.routers.mdp_api.tls: "true"
+      traefik.http.routers.mdp_api.tls.certresolver: "le"
+      traefik.http.routers.mdp_api.service: "mdp_api"
+
+      # Service backend (port interne)
       traefik.http.services.mdp_api.loadbalancer.server.port: "8000"
+
+      # ===== Pass-through API sous le domaine front (mdp.mon-site.ca) =====
+      # HTTP -> redirige
+      traefik.http.routers.mdp_api_on_front_http.rule: "Host(`mdp.mon-site.ca`) && PathPrefix(`/api/`)"
+      traefik.http.routers.mdp_api_on_front_http.entrypoints: "web"
+      traefik.http.routers.mdp_api_on_front_http.middlewares: "redirect-to-https"
+      traefik.http.routers.mdp_api_on_front_http.priority: "1000"
+      traefik.http.routers.mdp_api_on_front_http.service: "mdp_api"
+
+      # HTTPS -> sert l'API sous /api/*
+      traefik.http.routers.mdp_api_on_front.rule: "Host(`mdp.mon-site.ca`) && PathPrefix(`/api/`)"
+      traefik.http.routers.mdp_api_on_front.entrypoints: "websecure"
+      traefik.http.routers.mdp_api_on_front.tls: "true"
+      traefik.http.routers.mdp_api_on_front.tls.certresolver: "le"
+      traefik.http.routers.mdp_api_on_front.priority: "1000"
+      traefik.http.routers.mdp_api_on_front.service: "mdp_api"
+
     networks:
       - appnet
       - edge
@@ -68,8 +100,21 @@ services:
     labels:
       traefik.enable: "true"
       traefik.docker.network: "edge"
-      traefik.http.routers.mdp_front.rule: "Host(`mdp.mon-site.ca`)"
-      traefik.http.routers.mdp_front.entrypoints: "web"
+
+      # HTTP -> redirige (mais NE capture PAS /api/*)
+      traefik.http.routers.mdp_front_http.rule: "Host(`mdp.mon-site.ca`) && !PathPrefix(`/api/`)"
+      traefik.http.routers.mdp_front_http.entrypoints: "web"
+      traefik.http.routers.mdp_front_http.middlewares: "redirect-to-https"
+      traefik.http.routers.mdp_front_http.priority: "1"
+
+      # HTTPS -> sert le front (mais NE capture PAS /api/*)
+      traefik.http.routers.mdp_front.rule: "Host(`mdp.mon-site.ca`) && !PathPrefix(`/api/`)"
+      traefik.http.routers.mdp_front.entrypoints: "websecure"
+      traefik.http.routers.mdp_front.tls: "true"
+      traefik.http.routers.mdp_front.tls.certresolver: "le"
+      traefik.http.routers.mdp_front.priority: "1"
+
+      # Service front (port interne)
       traefik.http.services.mdp_front.loadbalancer.server.port: "80"
     networks:
       - edge


### PR DESCRIPTION
…ik, scripts backup/restore OK